### PR TITLE
performance improvements

### DIFF
--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -64,7 +64,7 @@ class FPDF(object):
         self.offsets = {}               # array of object offsets
         self.page = 0                   # current page number
         self.n = 2                      # current object number
-        self.buffer = ''                # buffer holding in-memory PDF
+        self.stream = BytesIO()         # stream holding in-memory PDF
         self.pages = {}                 # array containing pages and metadata
         self.state = 0                  # current document state
         self.fonts = {}                 # array of used fonts
@@ -144,6 +144,11 @@ class FPDF(object):
         self.set_compression(1)
         # Set default PDF version number
         self.pdf_version = '1.3'
+
+    @property
+    def buffer(self):
+        '''buffer holding in-memory PDF - backwards compatible'''
+        return self.stream.getvalue()
 
     @staticmethod
     def get_page_format(format, k):
@@ -1107,22 +1112,17 @@ class FPDF(object):
                 dest='I'
             else:
                 dest='F'
-        if PY3K:
-            # manage binary data as latin1 until PEP461 or similar is implemented
-            buffer = self.buffer.encode("latin1")
-        else:
-            buffer = self.buffer
         if dest in ('I', 'D'):
             # Python < 3 writes byte data transparently without "buffer"
             stdout = getattr(sys.stdout, 'buffer', sys.stdout)
-            stdout.write(buffer)
+            stdout.write(self.buffer)
         elif dest=='F':
             #Save to local file
             with open(name,'wb') as f:
-                f.write(buffer)
+                f.write(self.buffer)
         elif dest=='S':
             #Return as a byte string
-            return buffer
+            return self.buffer
         else:
             self.error('Incorrect output destination: '+dest)
 
@@ -1224,7 +1224,7 @@ class FPDF(object):
             self._putstream(p)
             self._out('endobj')
         # Pages root
-        self.offsets[1] = len(self.buffer)
+        self.offsets[1] = self.stream.tell()
         self._out('1 0 obj')
         self._out('<</Type /Pages')
         kids = '/Kids ['
@@ -1624,7 +1624,7 @@ class FPDF(object):
         self._putfonts()
         self._putimages()
         #Resource dictionary
-        self.offsets[2]=len(self.buffer)
+        self.offsets[2] = self.stream.tell()
         self._out('2 0 obj')
         self._out('<<')
         self._putresourcedict()
@@ -1688,7 +1688,7 @@ class FPDF(object):
         self._out('>>')
         self._out('endobj')
         #Cross-ref
-        o=len(self.buffer)
+        o = self.stream.tell()
         self._out('xref')
         self._out('0 '+(str(self.n+1)))
         self._out('0000000000 65535 f ')
@@ -1749,7 +1749,7 @@ class FPDF(object):
     def _newobj(self):
         #Begin a new object
         self.n+=1
-        self.offsets[self.n]=len(self.buffer)
+        self.offsets[self.n] = self.stream.tell()
         self._out(str(self.n)+' 0 obj')
 
     def _dounderline(self, x, y, txt):
@@ -1974,7 +1974,15 @@ class FPDF(object):
         if(self.state == 2):
             self.pages[self.page]["content"] += (s + "\n")
         else:
-            self.buffer += (s + "\n")
+            if PY3K:
+                if not isinstance(s, bytes):
+                    s = s.encode('latin1')
+                s += b"\n"
+            else:
+                if not instance(s, str):
+                    s = s.encode("latin1")    # default encoding (font name and similar)
+                s += "\n"
+            self.stream.write(s)
 
     @check_page
     def interleaved2of5(self, txt, x, y, w=1.0, h=10.0):


### PR DESCRIPTION
With this speedup, when you have various pages with png images, the
improvements is significant.
As a example, I used an old dual core machine, with 104 png images, to
generate a pdf, 1 image per page. The time consuming before was 1 minute
and 28 seconds. After this patch, the time is 6 seconds!!!
Yes, 6 seconds, 14,7x faster!